### PR TITLE
port library to support explicit-nulls

### DIFF
--- a/core/src/main/scala/algebra/instances/bigDecimal.scala
+++ b/core/src/main/scala/algebra/instances/bigDecimal.scala
@@ -2,7 +2,6 @@ package algebra
 package instances
 
 import java.math.MathContext
-
 import algebra.ring._
 
 package object bigDecimal extends BigDecimalInstances
@@ -12,7 +11,7 @@ trait BigDecimalInstances extends cats.kernel.instances.BigDecimalInstances {
 }
 
 class BigDecimalAlgebra(mc: MathContext) extends Field[BigDecimal] with Serializable {
-  def this() = this(MathContext.UNLIMITED)
+  def this() = this(MathContext.UNLIMITED.nn)
 
   val zero: BigDecimal = BigDecimal(0, mc)
   val one: BigDecimal = BigDecimal(1, mc)


### PR DESCRIPTION
Total LOC changed: 1
Usage of nn: 1

**Classification**
java.math.MathContext.UNLIMITED | FS
.nn required: 1
Documentation: Does not mention nullability, but this is a final static field. It is initialized with the class.
